### PR TITLE
added default placeholder image

### DIFF
--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -164,8 +164,10 @@ router.get("/:item", auth.optional, function(req, res, next) {
   ])
     .then(function(results) {
       var user = results[0];
-
-      return res.json({ item: req.item.toJSONFor(user) });
+      const item = req.item.toJSONFor(user)
+      if(!item?.image)
+        item.image = '/placeholder.png'
+      return res.json({ item });
     })
     .catch(next);
 });


### PR DESCRIPTION
# Description

When image link was not provided by user, broken image appear as api send empty image link.
I fixed it by providing a default placeholder image if image is not provided